### PR TITLE
Fix rich text blocks translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Strapi LLM Translator plugin enhances your localization workflow by utilisin
 
 ## 🚀 Key Features
 
-- 🌍 **Multi-field Support** - Translates all text-based fields (string, text, richtext)
+- 🌍 **Multi-field Support** - Translates all text-based fields (string, text, richtext) and JSON/Blocks content
 - 🔌 **LLM Agnostic** - Works with any OpenAI-compatible API (your choice of provider)
 - 📝 **Format Preservation** - Maintains markdown formatting during translation
 - 🔗 **Smart UUID Handling** - Auto-translates slugs when i18n is enabled with relative fields

--- a/server/src/services/llm-service.ts
+++ b/server/src/services/llm-service.ts
@@ -37,15 +37,17 @@ const extractTranslatableFields = (
     schema: Record<string, any> | undefined,
     value: any
   ): boolean => {
-    if (!schema || typeof value !== 'string') {
+    if (!schema) {
       return false;
     }
 
-    const isStringOrText = ['string', 'text', 'richtext'].includes(schema.type);
-    const isNotUID = schema.type !== 'uid';
+    const { type } = schema;
+    const isStringType = ['string', 'text', 'richtext'].includes(type) && typeof value === 'string';
+    const isJSONType = type === 'json' && typeof value === 'object';
+    const isNotUID = type !== 'uid';
     const isLocalizable = schema.pluginOptions?.i18n?.localized !== false;
 
-    return isStringOrText && isNotUID && isLocalizable;
+    return (isStringType || isJSONType) && isNotUID && isLocalizable;
   };
 
   const traverse = (

--- a/server/src/types/index.ts
+++ b/server/src/types/index.ts
@@ -48,7 +48,7 @@ export interface GenerateRequestBody {
 
 export interface TranslatableField {
   path: string[];
-  value: string;
+  value: any;
   originalPath: string[];
 }
 


### PR DESCRIPTION
## Summary
- allow JSON fields to be translated
- support complex values in TranslatableField type
- document JSON/Blocks support

## Testing
- `npm run test:ts:front` *(fails: run command not found)*
- `npm run test:ts:back` *(fails: run command not found)*