### PR TITLE
Fix rich text detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Strapi LLM Translator plugin enhances your localization workflow by utilisin
 
 ## 🚀 Key Features
 
-- 🌍 **Multi-field Support** - Translates all text-based fields (string, text, richtext) and JSON/Blocks content
+- 🌍 **Multi-field Support** - Translates all text-based fields (string, text, richtext) and JSON/Blocks content, including Strapi 5 structured rich text
 - 🔌 **LLM Agnostic** - Works with any OpenAI-compatible API (your choice of provider)
 - 📝 **Format Preservation** - Maintains markdown formatting during translation
 - 🔗 **Smart UUID Handling** - Auto-translates slugs when i18n is enabled with relative fields

--- a/server/src/services/llm-service.ts
+++ b/server/src/services/llm-service.ts
@@ -42,12 +42,18 @@ const extractTranslatableFields = (
     }
 
     const { type } = schema;
-    const isStringType = ['string', 'text', 'richtext'].includes(type) && typeof value === 'string';
+
+    const isStringType = ['string', 'text'].includes(type) && typeof value === 'string';
+
+    const isRichTextType =
+      ['richtext', 'richText', 'blocks'].includes(type) &&
+      (typeof value === 'string' || typeof value === 'object');
+
     const isJSONType = type === 'json' && typeof value === 'object';
     const isNotUID = type !== 'uid';
     const isLocalizable = schema.pluginOptions?.i18n?.localized !== false;
 
-    return (isStringType || isJSONType) && isNotUID && isLocalizable;
+    return (isStringType || isRichTextType || isJSONType) && isNotUID && isLocalizable;
   };
 
   const traverse = (


### PR DESCRIPTION
## Summary
- support Strapi 5 structured rich text (blocks)
- document rich text support in README

## Testing
- `npm run test:ts:back` *(fails: `run: not found`)*