### PR TITLE
Fix JSON parsing when translating mixed rich text

### DIFF
--- a/server/src/services/llm-service.ts
+++ b/server/src/services/llm-service.ts
@@ -15,7 +15,12 @@ import {
   SYSTEM_PROMPT_FIX,
   USER_PROMPT_FIX_PREFIX,
 } from '../config/constants';
-import { cleanJSONString, balanceJSONBraces, safeJSONParse } from '../utils/json-utils';
+import {
+  cleanJSONString,
+  balanceJSONBraces,
+  safeJSONParse,
+  extractJSONObject,
+} from '../utils/json-utils';
 
 const openai = new OpenAI({
   baseURL: process.env.STRAPI_ADMIN_LLM_TRANSLATOR_LLM_BASE_URL,
@@ -279,7 +284,7 @@ IMPORTANT RULES:
 4. Keep HTML tags intact if present
 5. Preserve any special characters or placeholders
 6. Return ONLY the translated JSON object
-7. Ensure the JSON is valid and well-formed, all values must be strings
+7. Ensure the JSON is valid and well-formed. Keep arrays and nested objects intact
 8. Do not add any explanations or comments
 9. Ensure professional and culturally appropriate translations
 
@@ -360,11 +365,12 @@ const parseLLMResponse = async (response: any): Promise<Record<string, any>> => 
     if (!content) throw new Error('No content in response');
 
     const cleanContent = cleanJSONString(content);
+    const jsonContent = extractJSONObject(cleanContent);
 
     try {
-      return safeJSONParse(cleanContent);
+      return safeJSONParse(jsonContent);
     } catch (parseError) {
-      const balancedContent = balanceJSONBraces(cleanContent);
+      const balancedContent = balanceJSONBraces(jsonContent);
 
       try {
         return safeJSONParse(balancedContent);

--- a/server/src/utils/json-utils.ts
+++ b/server/src/utils/json-utils.ts
@@ -19,6 +19,15 @@ export const balanceJSONBraces = (content: string): string => {
   return content;
 };
 
+export const extractJSONObject = (content: string): string => {
+  const firstBrace = content.indexOf('{');
+  const lastBrace = content.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
+    return content.slice(firstBrace, lastBrace + 1);
+  }
+  return content;
+};
+
 export const safeJSONParse = (content: string): Record<string, any> => {
   const parsed = JSON.parse(content);
   if (typeof parsed === 'object' && parsed !== null) {


### PR DESCRIPTION
## Summary
- extract JSON portion of LLM responses before parsing
- update prompt to keep arrays and nested objects intact

## Testing
- `npm run verify` *(fails: strapi-plugin not found)*